### PR TITLE
Add worker calendar API and improve gig filtering

### DIFF
--- a/src/Utils/CronManager.ts
+++ b/src/Utils/CronManager.ts
@@ -85,9 +85,7 @@ export class CronManager {
             "is_active" = false,
             "updated_at" = NOW()
           WHERE 
-            "date_end" = taipei_today
-            AND "is_active" = true
-            AND ("unlisted_at" IS NULL OR "unlisted_at" > taipei_today);
+            "date_end" = taipei_today;
         END;
         $$;
       `;


### PR DESCRIPTION
Introduces a new endpoint for workers to view their approved gigs in a calendar format, supporting both month and date range queries. Enhances employer gig and calendar APIs with consistent date filtering and status-based gig queries. Also simplifies the gig deactivation cron job logic.