### PR TITLE
Add rating system for gigs between employers and workers

### DIFF
--- a/drizzle/0006_daily_romulus.sql
+++ b/drizzle/0006_daily_romulus.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "employer_ratings" ADD COLUMN "gig_id" varchar(21) NOT NULL;--> statement-breakpoint
+ALTER TABLE "worker_ratings" ADD COLUMN "gig_id" varchar(21) NOT NULL;--> statement-breakpoint
+ALTER TABLE "employer_ratings" ADD CONSTRAINT "employer_ratings_gig_id_gigs_gig_id_fk" FOREIGN KEY ("gig_id") REFERENCES "public"."gigs"("gig_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "worker_ratings" ADD CONSTRAINT "worker_ratings_gig_id_gigs_gig_id_fk" FOREIGN KEY ("gig_id") REFERENCES "public"."gigs"("gig_id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,816 @@
+{
+  "id": "5caf582c-2693-4aa4-b1c8-f1f751c7e4ac",
+  "prevId": "bf910f8a-13ac-4331-bd21-f223f58e0846",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admins_email_unique": {
+          "name": "admins_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employer_ratings": {
+      "name": "employer_ratings",
+      "schema": "",
+      "columns": {
+        "rating_id": {
+          "name": "rating_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employer_id": {
+          "name": "employer_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_value": {
+          "name": "rating_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "employer_ratings_gig_id_gigs_gig_id_fk": {
+          "name": "employer_ratings_gig_id_gigs_gig_id_fk",
+          "tableFrom": "employer_ratings",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "gig_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "employer_ratings_employer_id_employers_employer_id_fk": {
+          "name": "employer_ratings_employer_id_employers_employer_id_fk",
+          "tableFrom": "employer_ratings",
+          "tableTo": "employers",
+          "columnsFrom": [
+            "employer_id"
+          ],
+          "columnsTo": [
+            "employer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "employer_ratings_worker_id_workers_worker_id_fk": {
+          "name": "employer_ratings_worker_id_workers_worker_id_fk",
+          "tableFrom": "employer_ratings",
+          "tableTo": "workers",
+          "columnsFrom": [
+            "worker_id"
+          ],
+          "columnsTo": [
+            "worker_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employers": {
+      "name": "employers",
+      "schema": "",
+      "columns": {
+        "employer_id": {
+          "name": "employer_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employer_name": {
+          "name": "employer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry_type": {
+          "name": "industry_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'其他'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "identification_type": {
+          "name": "identification_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'businessNo'"
+        },
+        "identification_number": {
+          "name": "identification_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_documents": {
+          "name": "verification_documents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employer_photo": {
+          "name": "employer_photo",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_info": {
+          "name": "contact_info",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employers_email_unique": {
+          "name": "employers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gig_applications": {
+      "name": "gig_applications",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gig_applications_worker_id_workers_worker_id_fk": {
+          "name": "gig_applications_worker_id_workers_worker_id_fk",
+          "tableFrom": "gig_applications",
+          "tableTo": "workers",
+          "columnsFrom": [
+            "worker_id"
+          ],
+          "columnsTo": [
+            "worker_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gig_applications_gig_id_gigs_gig_id_fk": {
+          "name": "gig_applications_gig_id_gigs_gig_id_fk",
+          "tableFrom": "gig_applications",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "gig_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gigs": {
+      "name": "gigs",
+      "schema": "",
+      "columns": {
+        "gig_id": {
+          "name": "gig_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "employer_id": {
+          "name": "employer_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_start": {
+          "name": "time_start",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_end": {
+          "name": "time_end",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_rate": {
+          "name": "hourly_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "district": {
+          "name": "district",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_photos": {
+          "name": "environment_photos",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_person": {
+          "name": "contact_person",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlisted_at": {
+          "name": "unlisted_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gigs_employer_id_employers_employer_id_fk": {
+          "name": "gigs_employer_id_employers_employer_id_fk",
+          "tableFrom": "gigs",
+          "tableTo": "employers",
+          "columnsFrom": [
+            "employer_id"
+          ],
+          "columnsTo": [
+            "employer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worker_ratings": {
+      "name": "worker_ratings",
+      "schema": "",
+      "columns": {
+        "rating_id": {
+          "name": "rating_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employer_id": {
+          "name": "employer_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_value": {
+          "name": "rating_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "worker_ratings_gig_id_gigs_gig_id_fk": {
+          "name": "worker_ratings_gig_id_gigs_gig_id_fk",
+          "tableFrom": "worker_ratings",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "gig_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_ratings_worker_id_workers_worker_id_fk": {
+          "name": "worker_ratings_worker_id_workers_worker_id_fk",
+          "tableFrom": "worker_ratings",
+          "tableTo": "workers",
+          "columnsFrom": [
+            "worker_id"
+          ],
+          "columnsTo": [
+            "worker_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "worker_ratings_employer_id_employers_employer_id_fk": {
+          "name": "worker_ratings_employer_id_employers_employer_id_fk",
+          "tableFrom": "worker_ratings",
+          "tableTo": "employers",
+          "columnsFrom": [
+            "employer_id"
+          ],
+          "columnsTo": [
+            "employer_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workers": {
+      "name": "workers",
+      "schema": "",
+      "columns": {
+        "worker_id": {
+          "name": "worker_id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_photo": {
+          "name": "profile_photo",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "highest_education": {
+          "name": "highest_education",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'大學'"
+        },
+        "school_name": {
+          "name": "school_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major": {
+          "name": "major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "study_status": {
+          "name": "study_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'就讀中'"
+        },
+        "certificates": {
+          "name": "certificates",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_experience": {
+          "name": "job_experience",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workers_email_unique": {
+          "name": "workers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1752934134705,
       "tag": "0005_jazzy_kate_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1753057475347,
+      "tag": "0006_daily_romulus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/Middleware/validator.ts
+++ b/src/Middleware/validator.ts
@@ -352,6 +352,12 @@ export const reviewApplicationSchema = z.object({
   }),
 });
 
+// 評分相關 Schema
+export const createRatingSchema = z.object({
+  ratingValue: z.number().int().min(1).max(5, "評分必須在1到5之間"),
+  comment: z.string().max(1000, "評論不能超過1000字").optional(),
+});
+
 // 通知相關 Schema
 export const createNotificationSchema = z.object({
   receiverId: z.string().min(1, "接收者ID不能為空"),

--- a/src/Routes/Rating.ts
+++ b/src/Routes/Rating.ts
@@ -1,0 +1,609 @@
+import { Router } from "@nhttp/nhttp";
+import { authenticated } from "../Middleware/middleware.ts";
+import { requireWorker, requireEmployer, requireApprovedEmployer } from "../Middleware/guards.ts";
+import type IRouter from "../Interfaces/IRouter.ts";
+import dbClient from "../Client/DrizzleClient.ts";
+import { eq, and, desc, sql, count } from "drizzle-orm";
+import { gigs, gigApplications, workers, employers, workerRatings, employerRatings } from "../Schema/DatabaseSchema.ts";
+import validate from "@nhttp/zod";
+import { createRatingSchema } from "../Middleware/validator.ts";
+import moment from "moment";
+
+const router = new Router();
+
+// ========== 商家對打工者評分（基於工作）==========
+
+/**
+ * 商家對打工者評分
+ * POST /rating/worker/:workerId/gig/:gigId
+ */
+router.post(
+  "/worker/:workerId/gig/:gigId",
+  authenticated,
+  requireEmployer,
+  requireApprovedEmployer,
+  validate(createRatingSchema),
+  async ({ user, params, body, response }) => {
+    try {
+      const { gigId, workerId } = params;
+      const { ratingValue, comment } = body;
+      const employerId = user.employerId;
+
+      // 檢查是否已經評分過
+      const existingRating = await dbClient
+        .select({ value: count() })
+        .from(workerRatings)
+        .where(and(eq(workerRatings.gigId, gigId), eq(workerRatings.workerId, workerId), eq(workerRatings.employerId, employerId)));
+
+      const hasRated = existingRating[0].value > 0;
+
+      if (hasRated) {
+        return response.status(400).send({
+          message: "您已經對這位打工者評分過了",
+        });
+      }
+
+      // 直接查詢符合所有條件的紀錄總數，並檢查工作是否已結束
+      const currentDate = moment().format("YYYY-MM-DD"); // YYYY-MM-DD 格式
+      const result = await dbClient
+        .select({ value: count() })
+        .from(gigs)
+        .innerJoin(
+          gigApplications,
+          and(
+            // JOIN 的條件
+            eq(gigs.gigId, gigApplications.gigId),
+            eq(gigApplications.workerId, workerId),
+            eq(gigApplications.status, "approved")
+          )
+        )
+        .where(
+          and(
+            // Gigs 表的過濾條件
+            eq(gigs.gigId, gigId),
+            eq(gigs.employerId, employerId),
+            sql`${gigs.dateEnd} < ${currentDate}` // 工作必須已結束
+          )
+        );
+
+      const exists = result[0].value > 0;
+
+      if (!exists) {
+        return response.status(404).send({
+          message: "找不到可評分的工作、指定的打工者沒有已批准的申請，或工作尚未結束",
+        });
+      }
+
+      // 創建評分
+      const [newRating] = await dbClient
+        .insert(workerRatings)
+        .values({
+          gigId,
+          workerId,
+          employerId,
+          ratingValue,
+          comment: comment || null,
+        })
+        .returning();
+
+      return response.status(201).send({
+        message: "評分成功",
+        data: {
+          ratingId: newRating.ratingId,
+          ratingValue: newRating.ratingValue,
+          comment: newRating.comment,
+          createdAt: newRating.createdAt,
+        },
+      });
+    } catch (error) {
+      console.error("評分打工者時發生錯誤:", error);
+      return response.status(500).send({
+        message: "評分失敗，請稍後再試",
+      });
+    }
+  }
+);
+
+/**
+ * 打工者對商家評分
+ * POST /rating/employer/:employerId/gig/:gigId
+ */
+router.post(
+  "/employer/:employerId/gig/:gigId",
+  authenticated,
+  requireWorker,
+  validate(createRatingSchema),
+  async ({ user, params, body, response }) => {
+    try {
+      const { gigId, employerId } = params;
+      const { ratingValue, comment } = body;
+      const workerId = user.workerId;
+
+      // 檢查是否已經評分過
+      const existingRating = await dbClient
+        .select({ value: count() })
+        .from(employerRatings)
+        .where(and(eq(employerRatings.gigId, gigId), eq(employerRatings.workerId, workerId), eq(employerRatings.employerId, employerId)));
+
+      const hasRated = existingRating[0].value > 0;
+
+      if (hasRated) {
+        return response.status(400).send({
+          message: "您已經對這個商家評分過了",
+        });
+      }
+      
+      // 直接查詢符合所有條件的紀錄總數，並檢查工作是否已結束
+      const currentDate = moment().format("YYYY-MM-DD"); // YYYY-MM-DD 格式
+      const result = await dbClient
+        .select({ value: count() })
+        .from(gigs)
+        .innerJoin(
+          gigApplications,
+          and(
+            // JOIN 的條件
+            eq(gigs.gigId, gigApplications.gigId),
+            eq(gigApplications.workerId, workerId),
+            eq(gigApplications.status, "approved")
+          )
+        )
+        .where(
+          and(
+            // Gigs 表的過濾條件
+            eq(gigs.gigId, gigId),
+            eq(gigs.employerId, employerId),
+            sql`${gigs.dateEnd} < ${currentDate}` // 工作必須已結束
+          )
+        );
+
+      const exists = result[0].value > 0;
+
+      if (!exists) {
+        return response.status(404).send({
+          message: "找不到可評分的工作、您沒有此工作的已批准申請，或工作尚未結束",
+        });
+      }
+
+      // 創建評分
+      const [newRating] = await dbClient
+        .insert(employerRatings)
+        .values({
+          gigId,
+          employerId,
+          workerId,
+          ratingValue,
+          comment: comment || null,
+        })
+        .returning();
+
+      return response.status(201).send({
+        message: "評分成功",
+        data: {
+          ratingId: newRating.ratingId,
+          ratingValue: newRating.ratingValue,
+          comment: newRating.comment,
+          createdAt: newRating.createdAt,
+        },
+      });
+    } catch (error) {
+      console.error("評分商家時發生錯誤:", error);
+      return response.status(500).send({
+        message: "評分失敗，請稍後再試",
+      });
+    }
+  }
+);
+
+// ========== 評分查詢 ==========
+
+/**
+ * 商家查看打工者的評分統計
+ * GET /rating/worker/:workerId
+ */
+router.get("/worker/:workerId", authenticated, requireEmployer, requireApprovedEmployer, async ({ params, response }) => {
+  try {
+    const { workerId } = params;
+
+    // 驗證打工者是否存在
+    const worker = await dbClient.query.workers.findFirst({
+      where: eq(workers.workerId, workerId),
+      columns: {
+        firstName: true,
+        lastName: true,
+      },
+    });
+
+    if (!worker) {
+      return response.status(404).send({
+        message: "找不到指定的打工者",
+      });
+    }
+
+    // 使用單一查詢計算總評數和總分
+    const ratingStats = await dbClient
+      .select({
+        count: count(),
+        average: sql<number>`coalesce(avg(${workerRatings.ratingValue}), 0)`,
+      })
+      .from(workerRatings)
+      .where(eq(workerRatings.workerId, workerId));
+
+    const totalRatings = ratingStats[0].count;
+    const averageRating = totalRatings > 0 ? ratingStats[0].average : 0;
+
+    return response.send({
+      data: {
+        worker: {
+          workerId,
+          name: `${worker.firstName} ${worker.lastName}`,
+        },
+        summary: {
+          totalRatings,
+          averageRating: Number(averageRating.toFixed(2)),
+        },
+      },
+    });
+  } catch (error) {
+    console.error("獲取打工者評分時發生錯誤:", error);
+    return response.status(500).send({
+      message: "獲取評分失敗，請稍後再試",
+    });
+  }
+});
+
+/**
+ * 打工者查看商家的評分統計
+ * GET /rating/employer/:employerId
+ */
+router.get("/employer/:employerId", authenticated, requireWorker, async ({ params, response }) => {
+  try {
+    const { employerId } = params;
+
+    // 驗證商家是否存在
+    const employer = await dbClient.query.employers.findFirst({
+      where: eq(employers.employerId, employerId),
+      columns: {
+        employerName: true,
+        branchName: true,
+      },
+    });
+
+    if (!employer) {
+      return response.status(404).send({
+        message: "找不到指定的商家",
+      });
+    }
+
+    // 使用單一查詢計算總評數和總分
+    const ratingStats = await dbClient
+      .select({
+        count: count(),
+        average: sql<number>`coalesce(avg(${workerRatings.ratingValue}), 0)`,
+      })
+      .from(employerRatings)
+      .where(eq(employerRatings.employerId, employerId));
+
+    const totalRatings = ratingStats[0].count;
+    const averageRating = totalRatings > 0 ? ratingStats[0].average : 0;
+
+    return response.send({
+      data: {
+        employer: {
+          employerId,
+          name: employer.branchName ? `${employer.employerName} - ${employer.branchName}` : employer.employerName,
+        },
+        summary: {
+          totalRatings,
+          averageRating: Number(averageRating.toFixed(2)),
+        },
+      },
+    });
+  } catch (error) {
+    console.error("獲取商家評分時發生錯誤:", error);
+    return response.status(500).send({
+      message: "獲取評分失敗，請稍後再試",
+    });
+  }
+});
+
+// ========== 我的評分 ==========
+
+/**
+ * 商家獲取自己給出的所有評分
+ * GET /rating/my-ratings/employer
+ */
+router.get("/my-ratings/employer", authenticated, requireEmployer, requireApprovedEmployer, async ({ user, response, query }) => {
+  try {
+    const { limit = 10, offset = 0 } = query;
+    const requestLimit = Number.parseInt(limit);
+    const requestOffset = Number.parseInt(offset);
+    const employerId = user.employerId;
+
+    // 獲取商家的所有評分
+    const myRatings = await dbClient.query.workerRatings.findMany({
+      where: eq(workerRatings.employerId, employerId),
+      columns: {
+        ratingId: true,
+        ratingValue: true,
+        comment: true,
+        createdAt: true,
+      },
+      with: {
+        worker: {
+          columns: {
+            workerId: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        gig: {
+          columns: {
+            gigId: true,
+            title: true,
+            dateEnd: true,
+          },
+        },
+      },
+      orderBy: [desc(workerRatings.createdAt)],
+      limit: requestLimit + 1, // 多查一筆來確認是否有更多資料
+      offset: requestOffset,
+    });
+
+    const hasMore = myRatings.length > requestLimit;
+    const returnRatings = hasMore ? myRatings.slice(0, requestLimit) : myRatings;
+
+    return response.send({
+      data: {
+        myRatings: returnRatings.map((rating) => ({
+          ratingId: rating.ratingId,
+          worker: {
+            workerId: rating.worker.workerId,
+            name: `${rating.worker.firstName} ${rating.worker.lastName}`,
+          },
+          gig: {
+            gigId: rating.gig.gigId,
+            title: rating.gig.title,
+            endDate: rating.gig.dateEnd,
+          },
+          ratingValue: rating.ratingValue,
+          comment: rating.comment,
+          createdAt: rating.createdAt,
+        })),
+        pagination: {
+          limit: requestLimit,
+          offset: requestOffset,
+          hasMore,
+          returned: returnRatings.length,
+        },
+      },
+    });
+  } catch (error) {
+    console.error("獲取商家評分記錄時發生錯誤:", error);
+    return response.status(500).send({
+      message: "獲取評分記錄失敗，請稍後再試",
+    });
+  }
+});
+
+/**
+ * 打工者獲取自己給出的所有評分
+ * GET /rating/my-ratings/worker
+ */
+router.get("/my-ratings/worker", authenticated, requireWorker, async ({ user, response, query }) => {
+  try {
+    const { limit = 10, offset = 0 } = query;
+    const requestLimit = Number.parseInt(limit);
+    const requestOffset = Number.parseInt(offset);
+    const workerId = user.workerId;
+
+    // 獲取打工者的所有評分
+    const myRatings = await dbClient.query.employerRatings.findMany({
+      where: eq(employerRatings.workerId, workerId),
+      columns: {
+        ratingId: true,
+        ratingValue: true,
+        comment: true,
+        createdAt: true,
+      },
+      with: {
+        employer: {
+          columns: {
+            employerId: true,
+            employerName: true,
+            branchName: true,
+          },
+        },
+        gig: {
+          columns: {
+            gigId: true,
+            title: true,
+            dateEnd: true,
+          },
+        },
+      },
+      orderBy: [desc(employerRatings.createdAt)],
+      limit: requestLimit + 1, // 多查一筆來確認是否有更多資料
+      offset: requestOffset,
+    });
+
+    const hasMore = myRatings.length > requestLimit;
+    const returnRatings = hasMore ? myRatings.slice(0, requestLimit) : myRatings;
+
+    return response.send({
+      data: {
+        myRatings: returnRatings.map((rating) => ({
+          ratingId: rating.ratingId,
+          employer: {
+            employerId: rating.employer.employerId,
+            name: rating.employer.branchName ? `${rating.employer.employerName} - ${rating.employer.branchName}` : rating.employer.employerName,
+          },
+          gig: {
+            gigId: rating.gig.gigId,
+            title: rating.gig.title,
+            endDate: rating.gig.dateEnd,
+          },
+          ratingValue: rating.ratingValue,
+          comment: rating.comment,
+          createdAt: rating.createdAt,
+        })),
+        pagination: {
+          limit: requestLimit,
+          offset: requestOffset,
+          hasMore,
+          returned: returnRatings.length,
+        },
+      },
+    });
+  } catch (error) {
+    console.error("獲取打工者評分記錄時發生錯誤:", error);
+    return response.status(500).send({
+      message: "獲取評分記錄失敗，請稍後再試",
+    });
+  }
+});
+
+// ========== 可評分列表 ==========
+
+/**
+ * 商家獲取可以評分的工作列表
+ * GET /rating/list/employer
+ */
+router.get("/list/employer", authenticated, requireEmployer, requireApprovedEmployer, async ({ user, response, query }) => {
+  try {
+    const { limit = 10, offset = 0 } = query;
+    const requestLimit = Number.parseInt(limit);
+    const requestOffset = Number.parseInt(offset);
+    const employerId = user.employerId;
+    const currentDate = moment().format("YYYY-MM-DD");
+
+    // 查詢該商家可評分的工作
+    const ratableGigs = await dbClient
+      .select({
+        gigId: gigs.gigId,
+        title: gigs.title,
+        dateEnd: gigs.dateEnd,
+        workerId: gigApplications.workerId,
+        workerFirstName: workers.firstName,
+        workerLastName: workers.lastName,
+      })
+      .from(gigs)
+      .innerJoin(gigApplications, and(
+        eq(gigs.gigId, gigApplications.gigId),
+        eq(gigApplications.status, "approved")
+      ))
+      .innerJoin(workers, eq(gigApplications.workerId, workers.workerId))
+      .leftJoin(workerRatings, and(
+        eq(gigs.gigId, workerRatings.gigId),
+        eq(gigApplications.workerId, workerRatings.workerId),
+        eq(workerRatings.employerId, employerId)
+      ))
+      .where(and(
+        eq(gigs.employerId, employerId),
+        sql`${gigs.dateEnd} < ${currentDate}`, // 工作必須已結束
+        sql`${workerRatings.ratingId} IS NULL` // 該商家未評分
+      ))
+      .orderBy(desc(gigs.dateEnd))
+      .limit(requestLimit + 1) // 多查一筆來確認是否有更多資料
+      .offset(requestOffset);
+
+    const hasMore = ratableGigs.length > requestLimit;
+    const returnGigs = hasMore ? ratableGigs.slice(0, requestLimit) : ratableGigs;
+
+    return response.send({
+      data: {
+        ratableGigs: returnGigs.map((gig) => ({
+          gigId: gig.gigId,
+          title: gig.title,
+          endDate: gig.dateEnd,
+          worker: {
+            workerId: gig.workerId,
+            name: `${gig.workerFirstName} ${gig.workerLastName}`,
+          },
+        })),
+        pagination: {
+          limit: requestLimit,
+          offset: requestOffset,
+          hasMore,
+          returned: returnGigs.length,
+        },
+      },
+    });
+  } catch (error) {
+    console.error("獲取可評分工作時發生錯誤:", error);
+    return response.status(500).send({
+      message: "獲取可評分工作失敗，請稍後再試",
+    });
+  }
+});
+
+/**
+ * 打工者獲取可以評分的工作列表
+ * GET /rating/list/worker
+ */
+router.get("/list/worker", authenticated, requireWorker, async ({ user, response, query }) => {
+  try {
+    const { limit = 10, offset = 0 } = query;
+    const requestLimit = Number.parseInt(limit);
+    const requestOffset = Number.parseInt(offset);
+    const workerId = user.workerId;
+    const currentDate = moment().format("YYYY-MM-DD");
+
+    // 查詢該打工者可評分的工作
+    const ratableGigs = await dbClient
+      .select({
+        gigId: gigs.gigId,
+        title: gigs.title,
+        dateEnd: gigs.dateEnd,
+        employerId: employers.employerId,
+        employerName: employers.employerName,
+        branchName: employers.branchName,
+      })
+      .from(gigApplications)
+      .innerJoin(gigs, eq(gigApplications.gigId, gigs.gigId))
+      .innerJoin(employers, eq(gigs.employerId, employers.employerId))
+      .leftJoin(employerRatings, and(
+        eq(gigs.gigId, employerRatings.gigId),
+        eq(employerRatings.workerId, workerId),
+        eq(employerRatings.employerId, gigs.employerId)
+      ))
+      .where(and(
+        eq(gigApplications.workerId, workerId),
+        eq(gigApplications.status, "approved"),
+        sql`${gigs.dateEnd} < ${currentDate}`, // 工作必須已結束
+        sql`${employerRatings.ratingId} IS NULL` // 該打工者未評分
+      ))
+      .orderBy(desc(gigs.dateEnd))
+      .limit(requestLimit + 1) // 多查一筆來確認是否有更多資料
+      .offset(requestOffset);
+
+    const hasMore = ratableGigs.length > requestLimit;
+    const returnGigs = hasMore ? ratableGigs.slice(0, requestLimit) : ratableGigs;
+
+    return response.send({
+      data: {
+        ratableGigs: returnGigs.map((gig) => ({
+          gigId: gig.gigId,
+          title: gig.title,
+          endDate: gig.dateEnd,
+          employer: {
+            employerId: gig.employerId,
+            name: gig.branchName ? `${gig.employerName} - ${gig.branchName}` : gig.employerName,
+          },
+        })),
+        pagination: {
+          limit: requestLimit,
+          offset: requestOffset,
+          hasMore,
+          returned: returnGigs.length,
+        },
+      },
+    });
+  } catch (error) {
+    console.error("獲取可評分工作時發生錯誤:", error);
+    return response.status(500).send({
+      message: "獲取可評分工作失敗，請稍後再試",
+    });
+  }
+});
+
+export default { path: "/rating", router } as IRouter;

--- a/src/Schema/DatabaseSchema.ts
+++ b/src/Schema/DatabaseSchema.ts
@@ -204,6 +204,11 @@ export const workerRatings = pgTable("worker_ratings", {
     .$defaultFn(() => nanoid())
     .primaryKey(),
 
+  // 關聯到具體的工作
+  gigId: varchar("gig_id", { length: 21 })
+    .notNull()
+    .references(() => gigs.gigId, { onDelete: "cascade" }),
+
   workerId: varchar("worker_id", { length: 21 })
     .notNull()
     .references(() => workers.workerId, { onDelete: "cascade" }),
@@ -224,6 +229,11 @@ export const employerRatings = pgTable("employer_ratings", {
   ratingId: varchar("rating_id", { length: 21 })
     .$defaultFn(() => nanoid())
     .primaryKey(),
+
+  // 關聯到具體的工作
+  gigId: varchar("gig_id", { length: 21 })
+    .notNull()
+    .references(() => gigs.gigId, { onDelete: "cascade" }),
 
   employerId: varchar("employer_id", { length: 21 })
     .notNull()
@@ -289,6 +299,8 @@ export const gigsRelations = relations(gigs, ({ one, many }) => ({
     references: [employers.employerId],
   }),
   gigApplications: many(gigApplications),
+  workerRatings: many(workerRatings),
+  employerRatings: many(employerRatings),
 }));
 
 // GigApplications
@@ -316,6 +328,10 @@ export const workerRatingsRelations = relations(workerRatings, ({ one }) => ({
     fields: [workerRatings.employerId],
     references: [employers.employerId],
   }),
+  gig: one(gigs, {
+    fields: [workerRatings.gigId],
+    references: [gigs.gigId],
+  }),
 }));
 
 // EmployerRatings
@@ -329,6 +345,10 @@ export const employerRatingsRelations = relations(
     worker: one(workers, {
       fields: [employerRatings.workerId],
       references: [workers.workerId],
+    }),
+    gig: one(gigs, {
+      fields: [employerRatings.gigId],
+      references: [gigs.gigId],
     }),
   }),
 );


### PR DESCRIPTION
Introduces a full rating system allowing employers and workers to rate each other per gig. Adds gig_id to both employer_ratings and worker_ratings tables with foreign key constraints, updates schema and relations, and implements rating-related API endpoints and validation schemas.