### PR TITLE
Refactor date filtering logic for gigs and ratings

### DIFF
--- a/src/Routes/Application.ts
+++ b/src/Routes/Application.ts
@@ -280,9 +280,21 @@ router.get("/worker/calendar", authenticated, requireWorker, async ({ user, quer
         )
       );
     } else if (hasDateRange) {
-      // 自訂日期範圍模式
-      dateStart ? whereConditions.push(gte(gigs.dateStart, dateStart)) : null;
-      dateEnd ? whereConditions.push(lte(gigs.dateEnd, dateEnd)) : null;
+      if (dateStart && dateEnd) {
+        // 工作期間與搜尋範圍有重疊
+        whereConditions.push(
+          and(
+            lte(gigs.dateStart, dateEnd),    // 工作開始 <= 搜尋結束
+            gte(gigs.dateEnd, dateStart)     // 工作結束 >= 搜尋開始
+          )
+        );
+      } else if (dateStart) {
+        // 只提供開始日期：工作結束日期 >= 搜尋開始日期
+        whereConditions.push(gte(gigs.dateEnd, dateStart));
+      } else if (dateEnd) {
+        // 只提供結束日期：工作開始日期 <= 搜尋結束日期
+        whereConditions.push(lte(gigs.dateStart, dateEnd));
+      }
     }
 
     // 執行資料庫查詢

--- a/src/Routes/Rating.ts
+++ b/src/Routes/Rating.ts
@@ -3,7 +3,7 @@ import { authenticated } from "../Middleware/middleware.ts";
 import { requireWorker, requireEmployer, requireApprovedEmployer } from "../Middleware/guards.ts";
 import type IRouter from "../Interfaces/IRouter.ts";
 import dbClient from "../Client/DrizzleClient.ts";
-import { eq, and, desc, sql, count } from "drizzle-orm";
+import { eq, and, desc, sql, count, lt } from "drizzle-orm";
 import { gigs, gigApplications, workers, employers, workerRatings, employerRatings } from "../Schema/DatabaseSchema.ts";
 import validate from "@nhttp/zod";
 import { createRatingSchema } from "../Middleware/validator.ts";
@@ -62,7 +62,7 @@ router.post(
             // Gigs 表的過濾條件
             eq(gigs.gigId, gigId),
             eq(gigs.employerId, employerId),
-            sql`${gigs.dateEnd} < ${currentDate}` // 工作必須已結束
+            lt(gigs.dateEnd, currentDate) // 工作必須已結束
           )
         );
 
@@ -152,7 +152,7 @@ router.post(
             // Gigs 表的過濾條件
             eq(gigs.gigId, gigId),
             eq(gigs.employerId, employerId),
-            sql`${gigs.dateEnd} < ${currentDate}` // 工作必須已結束
+            lt(gigs.dateEnd, currentDate) // 工作必須已結束
           )
         );
 
@@ -499,7 +499,7 @@ router.get("/list/employer", authenticated, requireEmployer, requireApprovedEmpl
       ))
       .where(and(
         eq(gigs.employerId, employerId),
-        sql`${gigs.dateEnd} < ${currentDate}`, // 工作必須已結束
+        lt(gigs.dateEnd, currentDate), // 工作必須已結束
         sql`${workerRatings.ratingId} IS NULL` // 該商家未評分
       ))
       .orderBy(desc(gigs.dateEnd))
@@ -569,7 +569,7 @@ router.get("/list/worker", authenticated, requireWorker, async ({ user, response
       .where(and(
         eq(gigApplications.workerId, workerId),
         eq(gigApplications.status, "approved"),
-        sql`${gigs.dateEnd} < ${currentDate}`, // 工作必須已結束
+        lt(gigs.dateEnd, currentDate), // 工作必須已結束
         sql`${employerRatings.ratingId} IS NULL` // 該打工者未評分
       ))
       .orderBy(desc(gigs.dateEnd))


### PR DESCRIPTION
Replaces raw SQL date comparisons with drizzle-orm operators (gt, lt, gte, lte) for consistency and readability in Gig and Rating routes. Updates date range filtering logic to ensure correct overlap handling in calendar endpoints. Adjusts public gig search to use dateEnd for filtering by start date.