### PR TITLE
Add rating stats to user profile and update dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,8 +10,8 @@
         "@types/nodemailer": "^6.4.17",
         "connect-redis": "^8.1.0",
         "cookie-signature": "^1.2.2",
-        "drizzle-kit": "^0.31.1",
-        "drizzle-orm": "^0.43.1",
+        "drizzle-kit": "^0.31.4",
+        "drizzle-orm": "^0.44.3",
         "express-session": "^1.18.1",
         "ioredis": "^5.6.1",
         "moment": "^2.30.1",
@@ -20,7 +20,7 @@
         "passport-local": "^1.0.0",
       },
       "devDependencies": {
-        "@types/bun": "^1.2.14",
+        "@types/bun": "^1.2.19",
         "@types/cookie-signature": "^1.1.2",
         "@types/express-session": "^1.18.1",
         "@types/moment": "^2.13.0",
@@ -94,13 +94,13 @@
 
     "@ioredis/commands": ["@ioredis/commands@1.2.0", "", {}, "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="],
 
-    "@jsr/nhttp__nhttp": ["@jsr/nhttp__nhttp@2.0.2", "https://npm.jsr.io/~/11/@jsr/nhttp__nhttp/2.0.2.tgz", {}, "sha512-D8AxN7hoBG13LEiYPsKSpybFsVZsU8Boh3mWSSL3bU67Jm2tB9uZY0Xsj8YlJtP5q7MKDb9oMiIK/H7uQLqR3Q=="],
+    "@jsr/nhttp__nhttp": ["@jsr/nhttp__nhttp@2.0.3", "https://npm.jsr.io/~/11/@jsr/nhttp__nhttp/2.0.3.tgz", {}, "sha512-HEDAtCJHebflPGvcz5/Xw3xlwyBXOcDlo8Ct3CRKoXI7x38qq0ZEfZ+T0Qt6WzvWrtZpAMfHQz4g60UMKRBr3A=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.10", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.9.0" } }, "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ=="],
 
-    "@nhttp/nhttp": ["@jsr/nhttp__nhttp@2.0.2", "https://npm.jsr.io/~/11/@jsr/nhttp__nhttp/2.0.2.tgz", {}, "sha512-D8AxN7hoBG13LEiYPsKSpybFsVZsU8Boh3mWSSL3bU67Jm2tB9uZY0Xsj8YlJtP5q7MKDb9oMiIK/H7uQLqR3Q=="],
+    "@nhttp/nhttp": ["@jsr/nhttp__nhttp@2.0.3", "https://npm.jsr.io/~/11/@jsr/nhttp__nhttp/2.0.3.tgz", {}, "sha512-HEDAtCJHebflPGvcz5/Xw3xlwyBXOcDlo8Ct3CRKoXI7x38qq0ZEfZ+T0Qt6WzvWrtZpAMfHQz4g60UMKRBr3A=="],
 
-    "@nhttp/zod": ["@jsr/nhttp__zod@2.0.2", "https://npm.jsr.io/~/11/@jsr/nhttp__zod/2.0.2.tgz", { "dependencies": { "@jsr/nhttp__nhttp": "^2.0.2", "zod": "3.23.8" } }, "sha512-98OFSLpEWAMEhOSv/EnS+oSwUvAllTdFt3le2YxwHzg/L4qcCl2KYU2Sd1an+Z2DRzWPpUlpUDczmMSK2xV44g=="],
+    "@nhttp/zod": ["@jsr/nhttp__zod@2.0.3", "https://npm.jsr.io/~/11/@jsr/nhttp__zod/2.0.3.tgz", { "dependencies": { "@jsr/nhttp__nhttp": "^2.0.3", "zod": "3.25.74" } }, "sha512-Y9pBfRGN0Ax+sTwEVHDgm1yA6xMHrnusjNV7WPYOoYpoTq50IlMXSwJI6InDKJfJxxCIcmkvLgawMCpukBf5pA=="],
 
     "@node-rs/argon2": ["@node-rs/argon2@2.0.2", "", { "optionalDependencies": { "@node-rs/argon2-android-arm-eabi": "2.0.2", "@node-rs/argon2-android-arm64": "2.0.2", "@node-rs/argon2-darwin-arm64": "2.0.2", "@node-rs/argon2-darwin-x64": "2.0.2", "@node-rs/argon2-freebsd-x64": "2.0.2", "@node-rs/argon2-linux-arm-gnueabihf": "2.0.2", "@node-rs/argon2-linux-arm64-gnu": "2.0.2", "@node-rs/argon2-linux-arm64-musl": "2.0.2", "@node-rs/argon2-linux-x64-gnu": "2.0.2", "@node-rs/argon2-linux-x64-musl": "2.0.2", "@node-rs/argon2-wasm32-wasi": "2.0.2", "@node-rs/argon2-win32-arm64-msvc": "2.0.2", "@node-rs/argon2-win32-ia32-msvc": "2.0.2", "@node-rs/argon2-win32-x64-msvc": "2.0.2" } }, "sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg=="],
 
@@ -138,7 +138,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.5", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg=="],
 
-    "@types/bun": ["@types/bun@1.2.14", "", { "dependencies": { "bun-types": "1.2.14" } }, "sha512-VsFZKs8oKHzI7zwvECiAJ5oSorWndIWEVhfbYqZd4HI/45kzW7PN2Rr5biAzvGvRuNmYLSANY+H59ubHq8xw7Q=="],
+    "@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -170,13 +170,15 @@
 
     "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
 
+    "@types/react": ["@types/react@19.1.8", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g=="],
+
     "@types/send": ["@types/send@0.17.4", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA=="],
 
     "@types/serve-static": ["@types/serve-static@1.15.7", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "*" } }, "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.2.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-Kuh4Ub28ucMRWeiUUWMHsT9Wcbr4H3kLIO72RZZElSDxSu7vpetRvxIUDUaW6QtaIeixIpm7OXtNnZPf82EzwA=="],
+    "bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
@@ -186,15 +188,17 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
     "debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
-    "drizzle-kit": ["drizzle-kit@0.31.1", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.2", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-PUjYKWtzOzPtdtQlTHQG3qfv4Y0XT8+Eas6UbxCmxTj7qgMf+39dDujf1BP1I+qqZtw9uzwTh8jYtkMuCq+B0Q=="],
+    "drizzle-kit": ["drizzle-kit@0.31.4", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA=="],
 
-    "drizzle-orm": ["drizzle-orm@0.43.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-dUcDaZtE/zN4RV/xqGrVSMpnEczxd5cIaoDeor7Zst9wOe/HzC/7eAaulywWGYXdDEc9oBPMjayVEDg0ziTLJA=="],
+    "drizzle-orm": ["drizzle-orm@0.44.3", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-8nIiYQxOpgUicEL04YFojJmvC4DNO4KoyXsEIqN44+g6gNBr6hmVpWk3uyAt4CaTiRGDwoU+alfqNNeonLAFOQ=="],
 
     "esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 
@@ -252,7 +256,7 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "zod": ["zod@3.23.8", "", {}, "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="],
+    "zod": ["zod@3.25.74", "", {}, "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "@types/nodemailer": "^6.4.17",
     "connect-redis": "^8.1.0",
     "cookie-signature": "^1.2.2",
-    "drizzle-kit": "^0.31.1",
-    "drizzle-orm": "^0.43.1",
+    "drizzle-kit": "^0.31.4",
+    "drizzle-orm": "^0.44.3",
     "express-session": "^1.18.1",
     "ioredis": "^5.6.1",
     "moment": "^2.30.1",
@@ -17,7 +17,7 @@
     "passport-local": "^1.0.0"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.14",
+    "@types/bun": "^1.2.19",
     "@types/cookie-signature": "^1.1.2",
     "@types/express-session": "^1.18.1",
     "@types/moment": "^2.13.0",

--- a/src/Middleware/guards.ts
+++ b/src/Middleware/guards.ts
@@ -1,8 +1,5 @@
 import type { Handler } from "@nhttp/nhttp";
 import { Role } from "../Types/types.ts";
-import { eq } from "drizzle-orm";
-import { employers } from "../Schema/DatabaseSchema.ts";
-import dbClient from "../Client/DrizzleClient.ts";
 
 // 角色檢查 Guard 函數
 export const requireRole = (...roles: Role[]): Handler => {
@@ -32,16 +29,11 @@ export const requireEmployerOrAdmin = requireRole(Role.EMPLOYER, Role.ADMIN);
 // 商家審核狀態檢查 Guard
 export const requireApprovedEmployer: Handler = async (rev, next) => {
   try {
-    const employer = await dbClient.query.employers.findFirst({
-      where: eq(employers.employerId, rev.user.employerId),
-      columns: {
-        approvalStatus: true,
-      },
-    });
-
-    //if (!employer || employer.approvalStatus !== "approved") {
-    //  return new Response("商家尚未通過審核，無法執行此操作", { status: 403 });
-    //}
+    /*
+    if (!rev.user.approvalStatus || rev.user.approvalStatus !== "approved") {
+      return new Response("商家尚未通過審核，無法執行此操作", { status: 403 });
+    }
+    */
 
     return next();
   } catch (error) {

--- a/src/Routes/Notification.ts
+++ b/src/Routes/Notification.ts
@@ -66,24 +66,29 @@ router.get("/list", authenticated, async ({ user, query, response }) => {
   }
 });
 
-// 獲取未讀通知數量
-router.get("/unread-count", authenticated, async ({ user, response }) => {
+// 獲取是否有未讀通知
+router.get("/unread", authenticated, async ({ user, response }) => {
   try {
-    const unreadCount = await dbClient.$count(notifications, and(
-      eq(notifications.receiverId, user.workerId || user.employerId || user.adminId),
-      eq(notifications.isRead, false)
-    ));
+    const unreadNotification = await dbClient.query.notifications.findFirst({
+      where: and(
+        eq(notifications.receiverId, user.workerId || user.employerId || user.adminId),
+        eq(notifications.isRead, false)
+      ),
+      columns: {
+        notificationId: true,
+      },
+    });
 
     return response.status(200).json({
       data: {
-        unreadCount,
+        hasUnread: !!unreadNotification,
       },
     });
 
   } catch (error) {
-    console.error("獲取未讀通知數量失敗:", error);
+    console.error("獲取未讀通知狀態失敗:", error);
     return response.status(500).json({
-      message: "獲取未讀通知數量失敗",
+      message: "獲取未讀通知狀態失敗",
     });
   }
 });

--- a/src/Routes/Rating.ts
+++ b/src/Routes/Rating.ts
@@ -3,7 +3,7 @@ import { authenticated } from "../Middleware/middleware.ts";
 import { requireWorker, requireEmployer, requireApprovedEmployer } from "../Middleware/guards.ts";
 import type IRouter from "../Interfaces/IRouter.ts";
 import dbClient from "../Client/DrizzleClient.ts";
-import { eq, and, desc, sql, count, lt } from "drizzle-orm";
+import { eq, and, desc, sql, count, lt, avg } from "drizzle-orm";
 import { gigs, gigApplications, workers, employers, workerRatings, employerRatings } from "../Schema/DatabaseSchema.ts";
 import validate from "@nhttp/zod";
 import { createRatingSchema } from "../Middleware/validator.ts";
@@ -231,7 +231,7 @@ router.get("/worker/:workerId", authenticated, requireEmployer, requireApprovedE
     const ratingStats = await dbClient
       .select({
         count: count(),
-        average: sql<number>`coalesce(avg(${workerRatings.ratingValue}), 0)`,
+        average: avg(workerRatings.ratingValue),
       })
       .from(workerRatings)
       .where(eq(workerRatings.workerId, workerId));
@@ -282,11 +282,11 @@ router.get("/employer/:employerId", authenticated, requireWorker, async ({ param
       });
     }
 
-    // 使用單一查詢計算總評數和總分
+    // 使用單一查詢計算總評數和平均分
     const ratingStats = await dbClient
       .select({
         count: count(),
-        average: sql<number>`coalesce(avg(${employerRatings.ratingValue}), 0)`,
+        average: avg(employerRatings.ratingValue),
       })
       .from(employerRatings)
       .where(eq(employerRatings.employerId, employerId));


### PR DESCRIPTION
User profile responses for both workers and employers now include total ratings and average rating statistics. The Notification unread endpoint is refactored to return a boolean for unread status instead of a count. The Rating routes now use the avg() function for average calculations. Unused employer approval DB checks are commented out in guards. Also updates several dependencies including drizzle-orm, drizzle-kit, and @types/bun.